### PR TITLE
Update operator to 15.12 

### DIFF
--- a/Logicalknn.cpp
+++ b/Logicalknn.cpp
@@ -4,7 +4,7 @@
  * @brief Brute force k nearest neighbors.
  *
  * @par Synopsis: knn(A, k).
- *  
+ *
  * @par Summary:
  * Simple brute force k nearest neighbor enumeration for a full distance
  * matrix. When used without a generic matrix input, it simply identifies
@@ -29,6 +29,9 @@
  */
 
 #include "query/Operator.h"
+
+using namespace std;
+
 namespace scidb
 {
 
@@ -50,7 +53,7 @@ public:
                  "entries contain the rank order of the k smallest values per row, or\n"
                  "or are empty otherwise. The output martix can be joined directly with\n"
                  "the input to mask it. Note that the diagonal would normally be filtered\n"
-                 "out of the solution with something like filter(knn(A,n),i<>j).\n\n" 
+                 "out of the solution with something like filter(knn(A,n),i<>j).\n\n"
                  "EXAMPLE:\n"
 "iquery -aq \"load_library('knn')\"\n"
 "export M=\"build(<x:double>[i=1:7,7,0,j=1:7,7,0],floor(abs(sin(i-j)*513))%10)\" \n"
@@ -78,9 +81,13 @@ public:
            throw SYSTEM_EXCEPTION(SCIDB_SE_INTERNAL, SCIDB_LE_ILLEGAL_OPERATION) <<  "knn requires a matrix input";
         if (matrix.getDimensions()[1].getChunkInterval() != static_cast<int64_t>(matrix.getDimensions()[1].getLength()))
             throw SYSTEM_EXCEPTION(SCIDB_SE_INTERNAL, SCIDB_LE_ILLEGAL_OPERATION) << "knn does not accept column partitioning of the input matrix, use repart first";
-        Attributes outputAttributes(matrix.getAttributes());
-        Dimensions outputDimensions(matrix.getDimensions());
-        return ArrayDesc(matrix.getName(), outputAttributes, outputDimensions);
+        ArrayDesc res(
+                matrix.getName(),
+                matrix.getAttributes(),
+                matrix.getDimensions(),
+                matrix.getDistribution(),
+                query->getDefaultArrayResidency());
+        return res;
     }
 };
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ifeq ($(SCIDB),) 
+ifeq ($(SCIDB),)
   X := $(shell which scidb 2>/dev/null)
   ifneq ($(X),)
     X := $(shell dirname ${X})
@@ -25,7 +25,9 @@ CFLAGS = -pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing \
          -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS \
          -Wno-system-headers -isystem  $(OPTIMIZED) -D_STDC_LIMIT_MACROS -std=c99
 CCFLAGS = -pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing \
-         -Wno-long-long -Wno-unused-parameter -fPIC $(OPTIMIZED) 
+         -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS \
+         -Wno-system-headers -isystem  $(OPTIMIZED) -D_STDC_LIMIT_MACROS \
+         -std=c++11 -DCPP11
 INC = -I. -DPROJECT_ROOT="\"$(SCIDB)\"" -I"$(SCIDB_3RDPARTY)/boost/include/" \
       -I"$(SCIDB)/include" -I./extern
 
@@ -35,6 +37,9 @@ LIBS = -shared -Wl,-soname,libknn.so -ldl -L. \
 
 SRCS = Logicalknn.cpp \
        Physicalknn.cpp
+
+CC := "/usr/bin/gcc-4.9"
+CXX := "/usr/bin/g++-4.9"
 
 all: libknn.so
 

--- a/Physicalknn.cpp
+++ b/Physicalknn.cpp
@@ -2,8 +2,8 @@
  *    _____      _ ____  ____
  *   / ___/_____(_) __ \/ __ )
  *   \__ \/ ___/ / / / / __  |
- *  ___/ / /__/ / /_/ / /_/ / 
- * /____/\___/_/_____/_____/  
+ *  ___/ / /__/ / /_/ / /_/ /
+ * /____/\___/_/_____/_____/
  *
  *
  * BEGIN_COPYRIGHT
@@ -28,6 +28,8 @@
 #include "query/Operator.h"
 #include "rowsort.h"
 
+using namespace std;
+
 namespace scidb
 {
 
@@ -40,12 +42,6 @@ public:
                 ArrayDesc const& schema):
         PhysicalOperator(logicalName, physicalName, parameters, schema)
     {}
-
-    virtual ArrayDistribution getOutputDistribution(vector<ArrayDistribution> const& inputDistributions,
-                                                    vector<ArrayDesc> const& inputSchemas) const
-    {
-       return inputDistributions[0];
-    }
 
     /**
       * [Optimizer API] Determine if operator changes result chunk distribution.


### PR DESCRIPTION
* Use new `ArrayDesc` API
* Remove `getOutputDistribution` member
* Use `gcc/g++` `4.9` with appropriate flags
* Use `std` namespace