### PR TITLE
Remove incorrectly used isystem flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ OPTIMIZED=-O2 -DNDEBUG
 DEBUG=-g -ggdb3
 CFLAGS = -pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing \
          -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS \
-         -Wno-system-headers -isystem  $(OPTIMIZED) -D_STDC_LIMIT_MACROS -std=c99
+         -Wno-system-headers $(OPTIMIZED) -D_STDC_LIMIT_MACROS -std=c99
 CCFLAGS = -pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing \
          -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS \
-         -Wno-system-headers -isystem  $(OPTIMIZED) -D_STDC_LIMIT_MACROS \
+         -Wno-system-headers $(OPTIMIZED) -D_STDC_LIMIT_MACROS \
          -std=c++11 -DCPP11
 INC = -I. -DPROJECT_ROOT="\"$(SCIDB)\"" -I"$(SCIDB_3RDPARTY)/boost/include/" \
       -I"$(SCIDB)/include" -I./extern


### PR DESCRIPTION
The `-isystem` flag needs to be followed by a directory, see [here](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html). Without the patch, the flag following `-isystem` is treated as a directory and has no effect.